### PR TITLE
fix: update go image version

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22.0
+FROM golang:1.23.0
 
 WORKDIR /app
 


### PR DESCRIPTION
## Issue

With [`air@latest`](https://github.com/air-verse/air?tab=readme-ov-file#via-go-install-recommended), it requires go 1.23 or higher.

The error occurred:
```
 => [server 2/6] WORKDIR /app                                                                            0.3s
 => ERROR [server 3/6] RUN go install github.com/air-verse/air@latest                                    2.3s
------
 > [server 3/6] RUN go install github.com/air-verse/air@latest:
1.680 go: downloading github.com/air-verse/air v1.60.0
1.983 go: github.com/air-verse/air@latest: github.com/air-verse/air@v1.60.0 requires go >= 1.23 (running go 1.22.0; GOTOOLCHAIN=local)
------
failed to solve: process "/bin/sh -c go install github.com/air-verse/air@latest" did not complete successfully: exit code: 1
```