### PR TITLE
lock versions to avoid breaking changes without

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,8 +1,8 @@
-FROM golang:1.22.0
+FROM golang:1.23.4
 
 WORKDIR /app
 
-RUN go install github.com/air-verse/air@latest
+RUN go install github.com/air-verse/air@v1.61.5
 
 COPY go.mod go.sum ./
 RUN go mod download

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -1,6 +1,6 @@
 module github.com/embrace-io/react-otel-101
 
-go 1.22.0
+go 1.23.4
 
 require (
 	ariga.io/atlas-provider-gorm v0.5.0
@@ -12,6 +12,7 @@ require (
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.28.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.28.0
 	go.opentelemetry.io/otel/sdk v1.28.0
+	go.opentelemetry.io/otel/sdk/metric v1.28.0
 	gorm.io/driver/postgres v1.5.9
 	gorm.io/gorm v1.25.10
 	gorm.io/plugin/opentelemetry v0.1.4
@@ -56,7 +57,6 @@ require (
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
 	github.com/ugorji/go/codec v1.2.12 // indirect
 	go.opentelemetry.io/otel/metric v1.28.0 // indirect
-	go.opentelemetry.io/otel/sdk/metric v1.28.0 // indirect
 	go.opentelemetry.io/otel/trace v1.28.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.3.1 // indirect
 	golang.org/x/arch v0.8.0 // indirect

--- a/backend/grafana.Dockerfile
+++ b/backend/grafana.Dockerfile
@@ -1,4 +1,4 @@
-FROM grafana/otel-lgtm
+FROM grafana/otel-lgtm@v0.8.2
 
 COPY tempo-config.yaml .
 


### PR DESCRIPTION
the demo app was not starting as it was, due to some breaking changes introduced by `@latest` versions. This locks everything into versions that are compatible one with each other